### PR TITLE
OSC.handle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ mido = "^1.3.0"
 python-osc = "^1.8.3"
 sounddevice = "^0.4.6"
 textual = "~0.41.0"
+pydantic = "^2.5.2"
+pydantic-numpy = "^4.1.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"

--- a/src/iipyper/osc.py
+++ b/src/iipyper/osc.py
@@ -472,16 +472,17 @@ class OSC():
                     address: full OSC address
                     *args: content of OSC message
                 """
+                # position of the next positional argument,
+                # -1 if no more are permitted
                 position = 0 if len(positional_params) or has_varp else -1
+
                 items = iter(osc_items)
                 args = []
                 kw = {}
 
+                # decide if an item represents the name of an argument,
+                # or is a positional argument or part of a Splat[None]
                 def is_key(item):
-                    # kwargs allowed
-                    # is a string
-                    # is the name of a parameter OR 
-                    #   there is a ** argument AND cannot be positional
                     # print(f"""
                     #     {kwargs=} 
                     #     and {isinstance(item, str)=} 
@@ -490,13 +491,11 @@ class OSC():
                     #         ))
                     #       """)
                     return (
-                        kwargs 
-                        and isinstance(item, str) 
-                        and (item in named_params or (
-                            has_varkw and position<0
-                            ))
+                        kwargs # named arguments enabled
+                        and isinstance(item, str) # can be a name
+                        and (item in named_params # is a known name
+                            or (has_varkw and position<0)) # or must be a ** arg
                     )
-
                 try:
                     _, item = _consume_items(None, items, None, is_key)
                     while item is not None:

--- a/src/iipyper/osc.py
+++ b/src/iipyper/osc.py
@@ -193,6 +193,9 @@ def _parse_osc_items(osc_items, sig_info, kwargs) -> Tuple[List, Dict[str, Any]]
                     raise
                 args.append(value)
                 position += 1
+                # check if this was the final positional argument
+                if position >= len(positional_params) and not has_varp:
+                    position = -1
             else:
                 raise ValueError("""
                 positional argument after keyword arg while parsing OSC

--- a/src/iipyper/types.py
+++ b/src/iipyper/types.py
@@ -1,11 +1,11 @@
-from typing import List, Tuple, TypeVar, Iterable, Any
+from typing import List, Tuple, TypeVar, Iterable, Any, Dict
 from typing_extensions import TypeAliasType
 import json
 
-import pydantic_numpy
 import numpy as np
 
-NDArray = pydantic_numpy.NpNDArray
+import pydantic_numpy
+from pydantic_numpy import NpNDArray as NDArray
 
 class _Splat(type):
     instances = {}

--- a/src/iipyper/types.py
+++ b/src/iipyper/types.py
@@ -17,7 +17,7 @@ class _Splat(type):
             r = Splat
         else:
             N = TypeVar('N')
-            Splat = TypeAliasType('Splat', Tuple[*[Any]*n], type_params=(N,))
+            Splat = TypeAliasType('Splat', Tuple[(Any,)*n], type_params=(N,))
             r = Splat[n]
         _Splat.instances[n] = r
         return r

--- a/src/iipyper/types.py
+++ b/src/iipyper/types.py
@@ -1,0 +1,57 @@
+from typing import List, Tuple, TypeVar, Iterable, Any
+from typing_extensions import TypeAliasType
+import json
+
+import pydantic_numpy
+import numpy as np
+
+NDArray = pydantic_numpy.NpNDArray
+
+class _Splat(type):
+    instances = {}
+    @staticmethod
+    def __getitem__(n):
+        if n in _Splat.instances: return _Splat.instances[n]
+        if n is None:
+            Splat = TypeAliasType('Splat', List)
+            r = Splat
+        else:
+            N = TypeVar('N')
+            Splat = TypeAliasType('Splat', Tuple[*[Any]*n], type_params=(N,))
+            r = Splat[n]
+        _Splat.instances[n] = r
+        return r
+class Splat(metaclass=_Splat):
+    """horrible typing crimes to produce annotations for _consume_items
+    which pydantic can also validate out of the box.
+
+    Splat[None] aliases List
+    Splat[2] aliases Tuple[Any, Any]
+    Splat[3] aliases Tuple[Any, Any, Any]
+    etc
+    """
+
+def ndarray_to_json(array: np.ndarray) -> str:
+    array_list = array.tolist()
+    array_info = {
+        'data': array_list,
+        'dtype': str(array.dtype),
+        'shape': array.shape
+    }
+    return json.dumps(array_info)
+
+def ndarray_from_json(json_str: str) -> np.ndarray:
+    data = json.loads(json_str)
+    array_data = data['data']
+    dtype = data['dtype']
+    r = np.array(array_data, dtype=dtype)
+    if 'shape' in data:
+        r = r.reshape(data['shape'])
+    return r
+
+def ndarray_from_repr(repr_str: str) -> np.ndarray:
+    from numpy import (array, 
+        float16, float32, float64,
+        complex64, complex128,
+        int8, int16, int32, int64)
+    return eval(repr_str)

--- a/src/iipyper/util.py
+++ b/src/iipyper/util.py
@@ -10,12 +10,12 @@ def profile(label, print=print):
     dt = (time.perf_counter_ns() - t)*1e-9
     print(f'{label}:\t {int(1000*dt)} ms')
 
-def maybe_lock(f, lock):
+def maybe_lock(f, lock, *a, **kw):
     if lock:
         with _lock:
-            return f()
+            return f(*a, **kw)
     else:
-        return f()
+        return f(*a, **kw)
 
 class Lag:
     def __init__(self, coef_up, coef_down=None, val=None):


### PR DESCRIPTION
new unified `OSC.handle` decorator. this cherry-picks and modifies some of the ndarray functions from `ja-dev` but I didn't merge the oscmap stuff from `ja-dev` yet.

should be backward compatible except in cases where `OSC.kwargs` was used with the `json_keys` argument, which will need to be converted to type annotations.

`from iipyper.types import *` is recommended to quickly import some `typing` types, the special `Splat` type, and the correct `NDArray` type (from pydantic_numpy)

adds dependencies on `pydantic` and `pydantic_numpy`.